### PR TITLE
Add the missing `id` attribute for scrolling to the top

### DIFF
--- a/template/default.twig
+++ b/template/default.twig
@@ -240,7 +240,7 @@
                 </aside>
 
                 <div class="col-lg-8 col-md-8 col-sm-8 col-xs-12 content">
-                    {% if title %}<h1>{{ title }} <small>{{ subTitle }}</small></h1>{% endif %}
+                    {% if title %}<h1 id="0">{{ title }} <small>{{ subTitle }}</small></h1>{% endif %}
                     {{ content|raw }}
 
                     <p class="fork-and-edit">


### PR DESCRIPTION
 * Added `id="0"` to the h1 element
 * Due to the missing attribute a `TypeError` would be thrown. Screenshot: https://i.imgur.com/ZWgVWh6.png
 * The exact problematic area was at the end of the minified JS. The attribute was missing so the `offset()` of the element was `undefined`, therefore the `TypeError`.
   Screenshot: https://i.imgur.com/gWJJDeM.png

Resolves #18