### PR TITLE
Adjust method visibility to make sense with the example

### DIFF
--- a/php/design_beautiful_classes_and_methods.md
+++ b/php/design_beautiful_classes_and_methods.md
@@ -26,7 +26,7 @@ class MyService {
         $this->logger = $logger;
     }
 
-    private function doStuff() {
+    public function doStuff() {
         // ...
         $this->logger->info('Hello world!');
     }


### PR DESCRIPTION
"Minor" fix:
Example is calling a public method, not a private one.

$myService = new MyService();

$myService->doStuff(); // BOOM! $this->logger is null!